### PR TITLE
Add support for unlabeled PRs

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -218,8 +218,6 @@ def main():
         if items:
             if label:
                 lines.append(f"\n**{label.upper()}**\n")
-            else:
-                lines.append(f"\n**UNLABELED**\n")
             changelog_pr = changelog_pr.union(set([x['html_url'] for x in items]))
             for x in pull_requests.get('items'):
                 items = [ generator(x) ]

--- a/changelog.py
+++ b/changelog.py
@@ -250,7 +250,7 @@ options = {
     'ivadomed': {
         'labels': ['bug', 'dependencies', 'documentation', 'enhancement'],
         'generator': default_changelog_generator,
-    },
+    }
 }
 
 if __name__ == '__main__':

--- a/changelog.py
+++ b/changelog.py
@@ -105,6 +105,8 @@ class GithubAPI(object):
         query = f'milestone:"{milestone}" is:pr repo:{self.repo_url} state:closed is:merged'
         if label:
             query += f' label:{label}'
+        else:
+            query += f' no:label'
         payload = {'q': query}
         r = self.request(url=url, params=payload).json()
         logger.info(f"Milestone: {milestone}, Label: {label}, Count: {r['total_count']}")
@@ -214,7 +216,10 @@ def main():
         pull_requests = api.search(milestone['title'], label)
         items = pull_requests.get('items')
         if items:
-            lines.append(f"\n**{label.upper()}**\n")
+            if label:
+                lines.append(f"\n**{label.upper()}**\n")
+            else:
+                lines.append(f"\n**UNLABELED**\n")
             changelog_pr = changelog_pr.union(set([x['html_url'] for x in items]))
             for x in pull_requests.get('items'):
                 items = [ generator(x) ]
@@ -244,6 +249,10 @@ options = {
     },
     'ivadomed': {
         'labels': ['bug', 'dependencies', 'documentation', 'enhancement'],
+        'generator': default_changelog_generator,
+    },
+    'data-multi-subject': {
+        'labels': [None],
         'generator': default_changelog_generator,
     }
 }

--- a/changelog.py
+++ b/changelog.py
@@ -240,7 +240,7 @@ def main():
 # provides customization to changelog for some repos
 options = {
     'default': {
-        'labels': ['bug', 'enhancement', 'feature', 'documentation'],
+        'labels': [None],
         'generator': default_changelog_generator,
     },
     'spinalcordtoolbox': {
@@ -251,10 +251,6 @@ options = {
         'labels': ['bug', 'dependencies', 'documentation', 'enhancement'],
         'generator': default_changelog_generator,
     },
-    'data-multi-subject': {
-        'labels': [None],
-        'generator': default_changelog_generator,
-    }
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Related PRs/Issues

Fixes #4.

### Description

 * Adds support for `'labels': [None]` in addition to the usual label strings.
 * Adds example usage for `data-multi-subject` repo.

Example output, `spine-generic_data-multi-subject_changelog.1.md`:

```md
## r20200826 (2020-08-28)
[View detailed changelog](https://github.com/spine-generic/data-multi-subject/compare/r20200826...r20200826)

**UNLABELED**

 - Added yml config file with subjects to exclude.  [View pull request](https://github.com/spine-generic/data-multi-subject/pull/11)
 - Updated participants.tsv.  [View pull request](https://github.com/spine-generic/data-multi-subject/pull/9)
 - Install git-annex to CI.  [View pull request](https://github.com/spine-generic/data-multi-subject/pull/6)
 - Updated git-annex documentation.  [View pull request](https://github.com/spine-generic/data-multi-subject/pull/4)
```

This corresponds to the unlabeled [merged PRs in `r20200826`](https://github.com/spine-generic/data-multi-subject/milestone/1?closed=1). Also, I tried adding a test label to one of the merged PRs, and doing that successfully excludes the PR, so all works as intended, I believe.