### PR TITLE
Add ADS category labels

### DIFF
--- a/changelog.py
+++ b/changelog.py
@@ -248,6 +248,10 @@ options = {
     'ivadomed': {
         'labels': ['bug', 'dependencies', 'documentation', 'enhancement'],
         'generator': default_changelog_generator,
+    },
+    'axondeepseg': {
+        'labels': ['bug', 'enhancement', 'feature', 'documentation', 'installation', 'testing'],
+        'generator': default_changelog_generator,
     }
 }
 


### PR DESCRIPTION
This is related to issue #7.
I added the axondeepseg project and category labels in changelog.py.