### PR TITLE
Add '--milestone' optional argument, change default sorting when it's not provided

### DIFF
--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+    #!/usr/bin/env python
 import sys
 import io
 import os
@@ -221,7 +221,6 @@ def get_parser():
     optional.add_argument(
         "--milestone",
         type=str,
-        default=None,
         help="Name of milestone to generate changelog for. If not provided, the most recently updated milestone is "
              "used instead."
     )

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -95,7 +95,7 @@ class GithubAPI(object):
                 logger.info(f"Requested milestone '{requested_title}' found in open milestones.")
             else:
                 raise ValueError(f"Requested milestone '{requested_title}' not found. "
-                                 f"Avaialble milestones: {[m['title'] for m in r]}.")
+                                 f"Available milestones: {[m['title'] for m in r]}.")
         else:
             milestone = sorted(r, key=lambda m: m['updated_at'], reverse=True)[0]
             logger.info(f"No milestone requested. Using most recently updated milestone: '{milestone['title']}'.")


### PR DESCRIPTION
This PR does two things:

* Adds the ability to specify milestone by name (Fixes #15.)
* If no name is specified, now a different sorting is used to select a milestone. Before, the oldest milestone (by creation date) was selected. Now, the most recently updated milestone is selected. (Fixes #22.)

Example usage:

```console
> changelog neuropoly/spinalcordtoolbox --milestone 5.2.1
INFO Checking API rate limits:
INFO Core api limit=60 remaining=60 reset=2021-03-06 19:39:25
INFO Search api limit=10 remaining=10 reset=2021-03-06 18:40:25
INFO Requested milestone '5.2.1' found in open milestones.
INFO Milestone: 5.2.1, Label: feature, Count: 0
INFO Milestone: 5.2.1, Label: documentation-internal, Count: 0
INFO Milestone: 5.2.1, Label: CI, Count: 1
INFO Milestone: 5.2.1, Label: bug, Count: 2
INFO Milestone: 5.2.1, Label: installation, Count: 0
INFO Milestone: 5.2.1, Label: documentation, Count: 1
INFO Milestone: 5.2.1, Label: enhancement, Count: 0
INFO Milestone: 5.2.1, Label: refactoring, Count: 0
INFO Milestone: 5.2.1, Label: git/github, Count: 1
INFO Total number of pull requests with label: 5
INFO Milestone: 5.2.1, Label: None, Count: 0
INFO Changelog written into neuropoly_spinalcordtoolbox_changelog.43.md

> changelog neuropoly/spinalcordtoolbox --milestone 5.2.2
INFO Checking API rate limits:
INFO Core api limit=60 remaining=58 reset=2021-03-06 19:39:25
INFO Search api limit=10 remaining=10 reset=2021-03-06 18:41:38
Traceback (most recent call last):
  File "/home/joshua/repos/changelog/venv/bin/changelog", line 33, in <module>
    sys.exit(load_entry_point('changelog-neuropoly', 'console_scripts', 'changelog')())
  File "/home/joshua/repos/changelog/changelog/changelog.py", line 232, in main
    milestone = api.get_milestone(args.milestone)
  File "/home/joshua/repos/changelog/changelog/changelog.py", line 97, in get_milestone
    raise ValueError(f"Requested milestone '{requested_title}' not found. "
ValueError: Requested milestone '5.2.2' not found. Available milestones: ['5.2.1', '5.3.0', '6.0.0'].

> changelog neuropoly/spinalcordtoolbox
INFO Checking API rate limits:
INFO Core api limit=60 remaining=53 reset=2021-03-06 19:39:25
INFO Search api limit=10 remaining=10 reset=2021-03-06 18:46:03
INFO Using most recently updated milestone: '5.2.1'
# [...]
```