### PR TITLE
Update publishing password.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_NEUROPOLY }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
@jcohenadad and I unified the naming scheme yesterday, so there's now a matching PYPY_NEUROPOLY token in the pypi.org account, and a matching TEST_PYPI_NEUROPOLY token in the test.pypi.org account.