### PR TITLE
Add commandline option for labels

### DIFF
--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -222,7 +222,8 @@ def get_parser():
 
     optional.add_argument("--labels",
                           nargs="+",
-                          help="Labels to update to the changelog",
+                          help="Labels to use for grouping PRs by category (the specified labels will be used "
+                               "as headers in the changelog)"
                           )
 
     optional.add_argument("--name",

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -220,6 +220,11 @@ def get_parser():
                           help="Update an existing changelog file by prepending to it.",
                           )
 
+    optional.add_argument("--labels",
+                          nargs="+",
+                          help="Labels to update to the changelog",
+                          )
+
     optional.add_argument("--name",
                           type=str,
                           default='CHANGES.md',
@@ -259,6 +264,8 @@ def main():
 
     changelog_pr = set()
     generator, labels = get_custom_options(repo)
+    if args.labels is not None:
+        labels = args.labels
 
     for label in labels:
         pull_requests = api.search(milestone['title'], label)


### PR DESCRIPTION
adding commandline option to use custom labels for the changelog, if commandline option is not specified, then it would use the hard coded default ones

resolves #29 