### PR TITLE
Remove standard install from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,7 @@
 Create a changelog file from all the merged pull requests
 
 ## Usage
-Install with pip (only do it once):
-
-### Standard install
-```
-pip install changelog-neuropoly
-```
-
-### Development install
+Development install:
 ````
 git clone git@github.com:neuropoly/changelog.git .
 cd changelog


### PR DESCRIPTION
As discussed in #31, this PR removes the instructions for standard install in the README to avoid confusion when updating the changelog manually and because the PyPI version is not maintained.