### PR TITLE
Improve SCT changelogs

### DIFF
--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -351,12 +351,28 @@ options = {
         'generator': sct_changelog_generator,
     },
     'ivadomed': {
-        'labels': ['feature', 'CI', 'bug', 'installation', 'documentation', 'dependencies', 'enhancement',
-                   'testing', 'refactoring'],
+        'labels': [
+            'feature',
+            'CI',
+            'bug',
+            'installation',
+            'documentation',
+            'dependencies',
+            'enhancement',
+            'testing',
+            'refactoring',
+        ],
         'generator': default_changelog_generator,
     },
     'axondeepseg': {
-        'labels': ['feature', 'bug', 'installation', 'documentation', 'enhancement', 'testing'],
+        'labels': [
+            'feature',
+            'bug',
+            'installation',
+            'documentation',
+            'enhancement',
+            'testing',
+        ],
         'generator': default_changelog_generator,
     }
 }

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -326,13 +326,13 @@ options = {
     'spinalcordtoolbox': {
         'labels': [
             'feature',
-            'documentation-internal',
-            'CI',
+            'enhancement',
             'bug',
             'installation',
             'documentation',
-            'enhancement',
+            'documentation-internal',
             'refactoring',
+            'CI',
             'git/github',
         ],
         'generator': sct_changelog_generator,

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -304,6 +304,7 @@ def main():
 
         backup = f"{filename}.bak"
         os.rename(filename, backup)
+        logger.info(f"Backup created: {backup}")
 
         with open(filename, 'w') as changelog:
             # re-use first line from existing file since it most likely contains the title
@@ -315,8 +316,6 @@ def main():
 
             # write back rest of changelog
             changelog.writelines(original[1:])
-
-        logger.info(f"Backup created: {backup}")
 
     else:
         filename = f"{user}_{repo}_changelog.{milestone['number']}.md"

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -133,7 +133,7 @@ class GithubAPI(object):
         if label:
             query += f' label:{label}'
         else:
-            query += f' no:label'
+            query += ' no:label'
         payload = {'q': query}
         r = self.request(url=url, params=payload).json()
         logger.info(f"Milestone: {milestone}, Label: {label}, Count: {r['total_count']}")
@@ -144,7 +144,7 @@ def get_custom_options(repo):
     """
     If repo has customizations defined for changelog use them, otherwise use defaults.
     """
-    if not repo in options:
+    if repo not in options:
         repo = 'default'
 
     generator, labels = options[repo]['generator'], options[repo]['labels']

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -191,7 +191,7 @@ def sct_changelog_generator(item):
         compat_msg = ""
 
     if sct_labels:
-        return f" - **{','.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})"
+        return f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})"
     else:
         return f" - {title}. {compat_msg} [View pull request]({pr_url})"
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -151,20 +151,23 @@ def get_custom_options(repo):
     return generator, labels
 
 
-def default_changelog_generator(item):
+def default_changelog_generator(items):
     """
     Contruct the default changelog line for a given item (PR).
     """
-    title = item['title']
-    breaks_compat = 'compatibility' in item['labels']
-    pr_url = item['html_url']
+    lines = []
+    for item in items:
+        title = item['title']
+        breaks_compat = 'compatibility' in item['labels']
+        pr_url = item['html_url']
 
-    if breaks_compat:
-        compat_msg = "**WARNING: Breaks compatibility with previous version.**"
-    else:
-        compat_msg = ""
+        if breaks_compat:
+            compat_msg = "**WARNING: Breaks compatibility with previous version.**"
+        else:
+            compat_msg = ""
 
-    return f" - {title}. {compat_msg} [View pull request]({pr_url})\n"
+        lines.append(f" - {title}. {compat_msg} [View pull request]({pr_url})\n")
+    return lines
 
 
 def get_sct_function_from_label(labels=[]):
@@ -175,24 +178,27 @@ def get_sct_function_from_label(labels=[]):
     return labels_list
 
 
-def sct_changelog_generator(item):
+def sct_changelog_generator(items):
     """
     Custom changelog line generator for sct project.
     """
-    title = item['title']
-    sct_labels = get_sct_function_from_label(item['labels'])
-    breaks_compat = 'compatibility' in item['labels']
-    pr_url = item['html_url']
+    lines = []
+    for item in items:
+        title = item['title']
+        sct_labels = get_sct_function_from_label(item['labels'])
+        breaks_compat = 'compatibility' in item['labels']
+        pr_url = item['html_url']
 
-    if breaks_compat:
-        compat_msg = "**WARNING: Breaks compatibility with previous version.**"
-    else:
-        compat_msg = ""
+        if breaks_compat:
+            compat_msg = "**WARNING: Breaks compatibility with previous version.**"
+        else:
+            compat_msg = ""
 
-    if sct_labels:
-        return f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})\n"
-    else:
-        return f" - {title}. {compat_msg} [View pull request]({pr_url})\n"
+        if sct_labels:
+            lines.append(f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})\n")
+        else:
+            lines.append(f" - {title}. {compat_msg} [View pull request]({pr_url})\n")
+    return lines
 
 
 def get_parser():
@@ -289,7 +295,7 @@ def main():
                     f"**{label.upper()}**\n",
                 ])
             changelog_pr = changelog_pr.union(pr['html_url'] for pr in items)
-            lines.extend(generator(pr) for pr in items)
+            lines.extend(generator(items))
 
     logger.info('Total number of pull requests with label: %d', len(changelog_pr))
     all_pr = set(pr['html_url'] for pr in api.search(milestone['title'])['items'])

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -180,7 +180,6 @@ def sct_changelog_generator(items):
         sct_labels = sorted(l['name'] for l in item['labels'] if "sct_" in l['name'])
         breaks_compat = any(l['name'] == 'compatibility' for l in item['labels'])
         pr_url = item['html_url']
-        sorting_key = (sct_labels, item['number'])
 
         if breaks_compat:
             compat_msg = "**WARNING: Breaks compatibility with previous version.** "
@@ -193,8 +192,10 @@ def sct_changelog_generator(items):
             labels_msg = ""
 
         line = f" - {labels_msg}{title}. {compat_msg}[View pull request]({pr_url})\n"
-        lines.append((sorting_key, line))
-    return [line for (key, line) in sorted(lines)]
+        # Sorting precedence: 1. PR labels > 2. PR number > 3. Line contents
+        # NB: CLI PRs (`sct_function`) are ordered before API PRs (denoted using 'x')
+        lines.append((sct_labels if sct_labels else ['x'], item['number'], line))
+    return [line for (pr_labels, pr_number, line) in sorted(lines)]
 
 
 def get_parser():

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -98,7 +98,7 @@ class GithubAPI(object):
         Get info about the most recently updated milestone.
         """
         open_milestones = self.fetch_open_milestones()
-        milestone = sorted(open_milestones, key=lambda m: m['updated_at'])[-1]
+        milestone = max(open_milestones, key=lambda m: m['updated_at'])
         logger.info(f"Using most recently updated milestone: '{milestone['title']}'")
         return milestone
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -238,6 +238,12 @@ def get_parser():
              "used instead."
     )
 
+    optional.add_argument(
+        "--use-milestone-due-date",
+        action='store_true',
+        help="Use the milestone due date as the release date, instead of today.",
+    )
+
     return parser
 
 
@@ -257,8 +263,14 @@ def main():
         milestone = api.get_most_recently_updated_milestone()
     tag = milestone['title'].split()[-1]
 
+    if args.use_milestone_due_date:
+        due_on = milestone['due_on'].replace('Z', '+00:00')
+        date = datetime.datetime.fromisoformat(due_on).date()
+    else:
+        date = datetime.date.today()
+
     lines = [
-        f"## {tag} ({datetime.date.today()})",
+        f"## {tag} ({date})",
         f"[View detailed changelog]({api.get_tags_compare_url(tag)})"
     ]
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -162,11 +162,11 @@ def default_changelog_generator(items):
         pr_url = item['html_url']
 
         if breaks_compat:
-            compat_msg = "**WARNING: Breaks compatibility with previous version.**"
+            compat_msg = "**WARNING: Breaks compatibility with previous version.** "
         else:
             compat_msg = ""
 
-        lines.append(f" - {title}. {compat_msg} [View pull request]({pr_url})\n")
+        lines.append(f" - {title}. {compat_msg}[View pull request]({pr_url})\n")
     return lines
 
 
@@ -183,7 +183,7 @@ def sct_changelog_generator(items):
         sorting_key = (sct_labels, item['number'])
 
         if breaks_compat:
-            compat_msg = "**WARNING: Breaks compatibility with previous version.**"
+            compat_msg = "**WARNING: Breaks compatibility with previous version.** "
         else:
             compat_msg = ""
 
@@ -192,7 +192,7 @@ def sct_changelog_generator(items):
         else:
             labels_msg = ""
 
-        line = f" - {labels_msg}{title}. {compat_msg} [View pull request]({pr_url})\n"
+        line = f" - {labels_msg}{title}. {compat_msg}[View pull request]({pr_url})\n"
         lines.append((sorting_key, line))
     return [line for (key, line) in sorted(lines)]
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -1,6 +1,5 @@
 # !/usr/bin/env python
 import sys
-import io
 import os
 import logging
 import datetime
@@ -290,13 +289,13 @@ def main():
         if not os.path.exists(filename):
             raise IOError(f"The provided changelog file: {filename} does not exist!")
 
-        with io.open(filename, 'r') as f:
+        with open(filename, 'r') as f:
             original = f.readlines()
 
         backup = f"{filename}.bak"
         os.rename(filename, backup)
 
-        with io.open(filename, 'w') as changelog:
+        with open(filename, 'w') as changelog:
             # re-use first line from existing file since it most likely contains the title
             changelog.write(original[0] + '\n')
 
@@ -311,7 +310,7 @@ def main():
 
     else:
         filename = f"{user}_{repo}_changelog.{milestone['number']}.md"
-        with io.open(filename, "w") as changelog:
+        with open(filename, "w") as changelog:
             changelog.write('\n'.join(lines))
 
     logger.info(f"Changelog written into {filename}")

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -158,7 +158,7 @@ def default_changelog_generator(items):
     lines = []
     for item in items:
         title = item['title']
-        breaks_compat = 'compatibility' in item['labels']
+        breaks_compat = any(l['name'] == 'compatibility' for l in item['labels'])
         pr_url = item['html_url']
 
         if breaks_compat:
@@ -178,7 +178,7 @@ def sct_changelog_generator(items):
     for item in items:
         title = item['title']
         sct_labels = [l['name'] for l in item['labels'] if "sct_" in l['name']]
-        breaks_compat = 'compatibility' in item['labels']
+        breaks_compat = any(l['name'] == 'compatibility' for l in item['labels'])
         pr_url = item['html_url']
 
         if breaks_compat:

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -170,14 +170,6 @@ def default_changelog_generator(items):
     return lines
 
 
-def get_sct_function_from_label(labels=[]):
-    labels_list = []
-    for label in labels:
-        if "sct_" in label['name']:
-            labels_list.append(label['name'])
-    return labels_list
-
-
 def sct_changelog_generator(items):
     """
     Custom changelog line generator for sct project.
@@ -185,7 +177,7 @@ def sct_changelog_generator(items):
     lines = []
     for item in items:
         title = item['title']
-        sct_labels = get_sct_function_from_label(item['labels'])
+        sct_labels = [l['name'] for l in item['labels'] if "sct_" in l['name']]
         breaks_compat = 'compatibility' in item['labels']
         pr_url = item['html_url']
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -324,8 +324,17 @@ options = {
         'generator': default_changelog_generator,
     },
     'spinalcordtoolbox': {
-        'labels': ['feature', 'documentation-internal', 'CI', 'bug', 'installation', 'documentation', 'enhancement',
-                   'refactoring', 'git/github'],
+        'labels': [
+            'feature',
+            'documentation-internal',
+            'CI',
+            'bug',
+            'installation',
+            'documentation',
+            'enhancement',
+            'refactoring',
+            'git/github',
+        ],
         'generator': sct_changelog_generator,
     },
     'ivadomed': {

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -167,18 +167,18 @@ def default_changelog_generator(item):
     return f" - {title}. {compat_msg} [View pull request]({pr_url})\n"
 
 
+def get_sct_function_from_label(labels=[]):
+    labels_list = []
+    for label in labels:
+        if "sct_" in label['name']:
+            labels_list.append(label['name'])
+    return labels_list
+
+
 def sct_changelog_generator(item):
     """
     Custom changelog line generator for sct project.
     """
-
-    def get_sct_function_from_label(labels=[]):
-        labels_list = []
-        for label in labels:
-            if "sct_" in label['name']:
-                labels_list.append(label['name'])
-        return labels_list
-
     title = item['title']
     sct_labels = get_sct_function_from_label(item['labels'])
     breaks_compat = 'compatibility' in item['labels']

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -177,9 +177,10 @@ def sct_changelog_generator(items):
     lines = []
     for item in items:
         title = item['title']
-        sct_labels = [l['name'] for l in item['labels'] if "sct_" in l['name']]
+        sct_labels = sorted(l['name'] for l in item['labels'] if "sct_" in l['name'])
         breaks_compat = any(l['name'] == 'compatibility' for l in item['labels'])
         pr_url = item['html_url']
+        sorting_key = (sct_labels, item['number'])
 
         if breaks_compat:
             compat_msg = "**WARNING: Breaks compatibility with previous version.**"
@@ -187,10 +188,13 @@ def sct_changelog_generator(items):
             compat_msg = ""
 
         if sct_labels:
-            lines.append(f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})\n")
+            labels_msg = f"**{', '.join(l for l in sct_labels)}**: "
         else:
-            lines.append(f" - {title}. {compat_msg} [View pull request]({pr_url})\n")
-    return lines
+            labels_msg = ""
+
+        line = f" - {labels_msg}{title}. {compat_msg} [View pull request]({pr_url})\n"
+        lines.append((sorting_key, line))
+    return [line for (key, line) in sorted(lines)]
 
 
 def get_parser():

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -281,17 +281,15 @@ def main():
 
     for label in labels:
         pull_requests = api.search(milestone['title'], label)
-        items = pull_requests.get('items')
+        items = pull_requests['items']
         if items:
             if label:
                 lines.append(f"\n**{label.upper()}**\n")
-            changelog_pr = changelog_pr.union(set([x['html_url'] for x in items]))
-            for x in pull_requests.get('items'):
-                items = [generator(x)]
-                lines.extend(items)
+            changelog_pr = changelog_pr.union(pr['html_url'] for pr in items)
+            lines.extend(generator(pr) for pr in items)
 
     logger.info('Total number of pull requests with label: %d', len(changelog_pr))
-    all_pr = set([x['html_url'] for x in api.search(milestone['title'])['items']])
+    all_pr = set(pr['html_url'] for pr in api.search(milestone['title'])['items'])
     diff_pr = all_pr - changelog_pr
     for diff in diff_pr:
         logger.warning('Pull request not labeled: %s', diff)

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -164,7 +164,7 @@ def default_changelog_generator(item):
     else:
         compat_msg = ""
 
-    return f" - {title}. {compat_msg} [View pull request]({pr_url})"
+    return f" - {title}. {compat_msg} [View pull request]({pr_url})\n"
 
 
 def sct_changelog_generator(item):
@@ -190,9 +190,9 @@ def sct_changelog_generator(item):
         compat_msg = ""
 
     if sct_labels:
-        return f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})"
+        return f" - **{', '.join(label for label in sct_labels)}:** {title}. {compat_msg} [View pull request]({pr_url})\n"
     else:
-        return f" - {title}. {compat_msg} [View pull request]({pr_url})"
+        return f" - {title}. {compat_msg} [View pull request]({pr_url})\n"
 
 
 def get_parser():
@@ -270,8 +270,8 @@ def main():
         date = datetime.date.today()
 
     lines = [
-        f"## {tag} ({date})",
-        f"[View detailed changelog]({api.get_tags_compare_url(tag)})"
+        f"## {tag} ({date})\n",
+        f"[View detailed changelog]({api.get_tags_compare_url(tag)})\n",
     ]
 
     changelog_pr = set()
@@ -284,7 +284,10 @@ def main():
         items = pull_requests['items']
         if items:
             if label:
-                lines.append(f"\n**{label.upper()}**\n")
+                lines.extend([
+                    "\n",
+                    f"**{label.upper()}**\n",
+                ])
             changelog_pr = changelog_pr.union(pr['html_url'] for pr in items)
             lines.extend(generator(pr) for pr in items)
 
@@ -308,11 +311,10 @@ def main():
 
         with open(filename, 'w') as changelog:
             # re-use first line from existing file since it most likely contains the title
-            changelog.write(original[0] + '\n')
+            changelog.writelines(original[:1] + ["\n"])
 
             # write current changelog
-            changelog.write('\n'.join(lines))
-            changelog.write('\n')
+            changelog.writelines(lines)
 
             # write back rest of changelog
             changelog.writelines(original[1:])
@@ -320,7 +322,7 @@ def main():
     else:
         filename = f"{user}_{repo}_changelog.{milestone['number']}.md"
         with open(filename, "w") as changelog:
-            changelog.write('\n'.join(lines))
+            changelog.writelines(lines)
 
     logger.info(f"Changelog written into {filename}")
 


### PR DESCRIPTION
Following [spinalcordtoolbox#3967](https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/3967), we have some suggestions for better formatting of the changelogs.

- [x] Re-order the sections in order of relevance.
- [x] Add spaces after commas in lists of labels.
- [x] Re-order the items within each section.
- [x] Take the release date from the milestone due date.