### PR TITLE
Add custom options for Shimming Toolbox

### DIFF
--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -142,21 +142,16 @@ class GithubAPI(object):
                    'per_page': 100,
                    'page': 0}
 
-        r = {'items': []}
-
-        received_items = 0
+        items = []
         total_count = 1
-        while received_items < total_count:
+        while len(items) < total_count:
             payload['page'] += 1
-            r_temp = self.request(url=url, params=payload).json()
-            total_count = r_temp['total_count']
-            received_items += len(r_temp['items'])
-            r['items'].extend(r_temp['items'])
-            r['total_count'] = r_temp['total_count']
-            r['incomplete_results'] = r_temp.get('incomplete_results')
+            response = self.request(url=url, params=payload).json()
+            total_count = response['total_count']
+            items.extend(response['items'])
 
-        logger.info(f"Milestone: {milestone}, Label: {label}, Count: {r['total_count']}")
-        return r
+        logger.info(f"Milestone: {milestone}, Label: {label}, Count: {total_count}")
+        return items
 
 
 def escape(string):
@@ -388,8 +383,7 @@ def main():
 
     if header_labels:
         for header_label in header_labels:
-            pull_requests = api.search(milestone['title'], header_label)
-            items = pull_requests['items']
+            items = api.search(milestone['title'], header_label)
             if items:
                 # If a single header is given as an input, don't add H3
                 if header_label and len(header_labels) >= 2:
@@ -403,8 +397,7 @@ def main():
                 changelog_pr.update(some_changelog_pr)
     else:
         for label in labels:
-            pull_requests = api.search(milestone['title'], label)
-            items = pull_requests['items']
+            items = api.search(milestone['title'], label)
             if items:
                 if label:
                     lines.extend([
@@ -415,7 +408,7 @@ def main():
                 lines.extend(generator(items))
 
     logger.info('Total number of pull requests with label: %d', len(changelog_pr))
-    all_pr = set(pr['html_url'] for pr in api.search(milestone['title'])['items'])
+    all_pr = set(pr['html_url'] for pr in api.search(milestone['title']))
     diff_pr = all_pr - changelog_pr
     for diff in diff_pr:
         logger.warning('Pull request not labeled: %s', diff)

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -134,8 +134,24 @@ class GithubAPI(object):
             query += f' label:"{label}"'
         else:
             query += ' no:label'
-        payload = {'q': query}
-        r = self.request(url=url, params=payload).json()
+
+        payload = {'q': query,
+                   'per_page': 100,
+                   'page': 0}
+
+        r = {'items': []}
+
+        received_items = 0
+        total_count = 1
+        while received_items < total_count:
+            payload['page'] += 1
+            r_temp = self.request(url=url, params=payload).json()
+            total_count = r_temp['total_count']
+            received_items += len(r_temp['items'])
+            r['items'].extend(r_temp['items'])
+            r['total_count'] = r_temp['total_count']
+            r['incomplete_results'] = r_temp.get('incomplete_results')
+
         logger.info(f"Milestone: {milestone}, Label: {label}, Count: {r['total_count']}")
         return r
 

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -354,19 +354,21 @@ def main():
         labels = args.labels
 
     if repo == 'shimming-toolbox':
-        for label in labels:
-            pull_requests = api.search(milestone['title'], label)
+        packages = labels
+        for package in packages:
+            pull_requests = api.search(milestone['title'], package)
             items = pull_requests['items']
             if items:
-                if label:
+                # If a single Package is given as an input, don't add H3
+                if package and len(packages) >= 2:
                     lines.extend([
                         "\n",
-                        f"### {label.upper()}\n",
+                        f"### {package.upper()}\n",
                     ])
 
-                    some_lines, some_changelog_pr = generator(items)
-                    lines.extend(some_lines)
-                    changelog_pr = changelog_pr.union(some_changelog_pr)
+                some_lines, some_changelog_pr = generator(items)
+                lines.extend(some_lines)
+                changelog_pr = changelog_pr.union(some_changelog_pr)
     else:
         for label in labels:
             pull_requests = api.search(milestone['title'], label)
@@ -472,12 +474,12 @@ options = {
             'refactoring',
         ],
         'labels': [
-            'Repo',
+            'Package: Shimming Toolbox',
             'Package: Plugin',
-            'Package: Shimming Toolbox'
+            'Repo',
         ],
         'generator': st_changelog_generator,
-    }
+    },
 }
 
 if __name__ == '__main__':

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -149,7 +149,7 @@ class GithubAPI(object):
         items = []
         response = self.request(url=url, params=payload)
         while True:
-            items.append(response.json()['items'])
+            items.extend(response.json()['items'])
             next_link = RE_NEXT_LINK.search(response.headers.get('link', ''))
             if next_link:
                 response = self.request(url=next_link[1])

--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -197,10 +197,7 @@ def default_header_changelog_generator(items, labels, line_generator):
         for label in item['labels']:
             label_name = label['name']
             if label_name in labels:
-                if label_name not in label_sorted_items.keys():
-                    label_sorted_items[label_name] = [item]
-                else:
-                    label_sorted_items[label_name].append(item)
+                label_sorted_items.setdefault(label_name, []).append(item)
 
     changelog_pr = set()
     for label_used in label_sorted_items.keys():
@@ -300,7 +297,7 @@ def get_parser():
                           )
 
     optional.add_argument("--header-labels",
-                          nargs="*",
+                          nargs="+",
                           help="Labels to use for grouping PRs into sections which will be subdivided "
                                "by categories using '--labels'. (the specified '--header-labels' will be used "
                                "as headers in the changelog unless only one is provided). When using this tag, "
@@ -379,7 +376,7 @@ def main():
 
                 some_lines, some_changelog_pr = default_header_changelog_generator(items, labels, generator)
                 lines.extend(some_lines)
-                changelog_pr = changelog_pr.union(some_changelog_pr)
+                changelog_pr.update(some_changelog_pr)
     else:
         for label in labels:
             pull_requests = api.search(milestone['title'], label)
@@ -390,7 +387,7 @@ def main():
                         "\n",
                         f"**{label.upper()}**\n",
                     ])
-                changelog_pr = changelog_pr.union(pr['html_url'] for pr in items)
+                changelog_pr.update(pr['html_url'] for pr in items)
                 lines.extend(generator(items))
 
     logger.info('Total number of pull requests with label: %d', len(changelog_pr))


### PR DESCRIPTION
Add custom options and layout for Shimming Toolbox.

- Labels with spaces (" ") were not handled properly. I updated the call when labels were used with extra "" and are now handled properly.
- ST has multiple packages so I added an extra option that allows to specify labels that create extra sections ("--header-labels".